### PR TITLE
Add multi-lingual metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 * Hundreds of customization options
 * Robust menu with both onepage and regular pages support
 * Complete blog layout
+* Multi-lingual metadata
 
 ![](hola-mobile.jpg)
 
@@ -85,6 +86,11 @@ custom_logo_mobile:
 
 Alternatively, you can you use the drag-n-drop "Custom Logo" field in the Hola theme options.
 
+## Multi-lingual metadata
+
+Hola theme supports metadata for different languages
+
+Copy the metadata you need from [Metadata - Grav Documentation](https://learn.getgrav.org/hints-tips/blogging/metadata) and paste it to your `user/pages/01._home/modular.lang.md`after `onpage_menu: false` for example.
 
 ## Sources and Credits
 

--- a/templates/partials/metadata.html.twig
+++ b/templates/partials/metadata.html.twig
@@ -1,0 +1,3 @@
+{% for meta in page.metadata %}
+    <meta {% if meta.name %}name="{{ meta.name }}" {% endif %}{% if meta.http_equiv %}http-equiv="{{ meta.http_equiv }}" {% endif %}{% if meta.charset %}charset="{{ meta.charset }}" {% endif %}{% if meta.property %}property="{{ meta.property }}" {% endif %}{% if meta.content %}content="{{ meta.content }}" {% endif %}/>
+{% endfor %}


### PR DESCRIPTION
The call for modular.html.twig is already present in base.html.twig
Tested here : [alexgaley.fr](https://alexgaley.fr)