### PR TITLE
Link in Logo not working as expected

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -49,7 +49,7 @@
         {% block header %}
             <header class="s-header">
                 <div class="header-logo">
-                    <a class="footer-site-logo" href="{{ base_url_relative }}">
+                    <a class="footer-site-logo" href="{{ home_url }}">
                         {% include 'partials/logo.html.twig' %}
                     </a>
                 </div>


### PR DESCRIPTION
The logo wasn't linking back to the frontpage when you were on another page. This change made it work as expected. Going back to the true home of the website, instead of just reloading the current page.